### PR TITLE
CIP-30 Change license installation strategy

### DIFF
--- a/modules/consul-cluster/consul-server.hcl
+++ b/modules/consul-cluster/consul-server.hcl
@@ -25,3 +25,4 @@ acl {
  }
 ui = true
 client_addr = "0.0.0.0"
+license_path = "/etc/consul.d/license.hclic"

--- a/modules/consul-cluster/consul-server.hcl.tmpl
+++ b/modules/consul-cluster/consul-server.hcl.tmpl
@@ -54,3 +54,4 @@ ca_file = "/etc/consul.d/ca"
 verify_outgoing = true
 verify_incoming = true
 verify_server_hostname = true
+license_path = "/etc/consul.d/license.hclic"

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -137,8 +137,25 @@ provisioner "file" {
   }
 }
 
+provisioner "file" {
+  destination = "/tmp/consul_license.hclic"
+  content     = var.license
+
+  connection {
+    type                = "ssh"
+    user                = var.ssh_user
+    private_key         = var.ssh_private_key
+    timeout             = var.ssh_timeout
+    host                = var.cluster_nodes_public_ips != null ? var.cluster_nodes_public_ips[each.key] : each.value
+    bastion_host        = var.ssh_bastion_host
+    bastion_port        = var.ssh_bastion_port
+    bastion_private_key = var.ssh_bastion_private_key
+    bastion_user        = var.ssh_bastion_user
+  }
+}
+
 provisioner "remote-exec" {
-  inline = ["sudo mv vault.vars /root/vault.vars; sudo mv /tmp/consul.hcl /etc/consul.d/consul.hcl && sudo mv /tmp/consul.hcl.tmpl /etc/consul.d/consul.hcl.tmpl && sudo mv /tmp/ca.tmpl /etc/consul.d/ca.tmpl && sudo mv /tmp/cert.tmpl /etc/consul.d/cert.tmpl && sudo mv /tmp/keyfile.tmpl /etc/consul.d/keyfile.tmpl"]
+  inline = ["sudo mv vault.vars /root/vault.vars; sudo mv /tmp/consul.hcl /etc/consul.d/consul.hcl && sudo mv /tmp/consul.hcl.tmpl /etc/consul.d/consul.hcl.tmpl && sudo mv /tmp/ca.tmpl /etc/consul.d/ca.tmpl && sudo mv /tmp/cert.tmpl /etc/consul.d/cert.tmpl && sudo mv /tmp/keyfile.tmpl /etc/consul.d/keyfile.tmpl && sudo mv /tmp/consul_license.hclic /etc/consul.d/license.hclic"]
   connection {
     type                = "ssh"
     user                = var.ssh_user
@@ -203,7 +220,7 @@ connection {
 }
 }
 provisioner "remote-exec" {
-  inline = ["chmod +x /tmp/consul_acl_bootstrap.sh && export LICENSE=\"${var.license}\" && sh /tmp/consul_acl_bootstrap.sh"]
+  inline = ["chmod +x /tmp/consul_acl_bootstrap.sh && sh /tmp/consul_acl_bootstrap.sh"]
   connection {
     type                = "ssh"
     user                = var.ssh_user

--- a/modules/consul-cluster/scripts/consul_acl_bootstrap.sh
+++ b/modules/consul-cluster/scripts/consul_acl_bootstrap.sh
@@ -49,10 +49,4 @@ export `sudo sh /root/vault.vars` && \
   vault kv put secret/consul/bootstrap_token secretid="`sudo cat /root/tokens | awk '/Secret/{print $2}'`" accessorid="`sudo cat /root/tokens | awk '/Access/{print $2}'`"
 }
 
-if [[ -n $${LICENSE} ]]
-then
-  echo "Adding Consul License..."
-  echo "$${LICENSE}" | consul license put -token="$(sudo cat /root/tokens | awk '/Secret/{print $2}')" -
-fi
-
 sudo rm -f /root/tokens


### PR DESCRIPTION
TODO:

- [ ] OSS: check if license_path does not cause any problem
- [ ] ENT: check if it is working

Requires Consul v1.10.0-beta3

@efbar same as per https://github.com/bitrockteam/caravan-nomad/pull/15, do we want to support both strategies?